### PR TITLE
Unify env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,19 @@ Docker images are available on [DockerHub][docker].
 
 1. Set the following environment variables:
 
-* `AXIOM_URL`: **https://cloud.axiom.co**
 * `AXIOM_TOKEN`: **Personal Access** or **Ingest** token. Can be
 created under `Profile` or `Settings > Ingest Tokens`. For security reasons it
 is advised to use an Ingest Token with minimal privileges only.
 
-1. Run it: `./axiom-honeycomb-proxy` or using docker:
+When using Axiom Selfhost:
+
+* `AXIOM_URL`: URL of the Axiom deployment to use.
+
+2. Run it: `./axiom-honeycomb-proxy` or using Docker:
 
 ```shell
 docker run -p8080:8080/tcp \
-  -e=AXIOM_URL=<https://cloud.axiom.co> \
-  -e=AXIOM_TOKEN=<xapt-xxxxx-xxxxxx> \
+  -e=AXIOM_TOKEN=<YOUR_AXIOM_TOKEN> \
   axiomhq/axiom-honeycomb-proxy
 ```
 

--- a/cmd/axiom-honeycomb-proxy/main.go
+++ b/cmd/axiom-honeycomb-proxy/main.go
@@ -25,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	if deploymentURL == "" {
-		log.Fatal("missing AXIOM_URL")
+		deploymentURL = axiom.CloudURL
 	}
 	if accessToken == "" {
 		log.Fatal("missing AXIOM_TOKEN")


### PR DESCRIPTION
* Default to Axiom Cloud URL, if env var is unset.
* Some doc improvements I prefer, because `xapt-` implies a personal token is needed.